### PR TITLE
  [RFC]  patch 8.0.0749: some unicode digraphs are hard to remember

### DIFF
--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -1359,6 +1359,12 @@ static digr_T digraphdefault[] =
   { 'f', 't', 0xfb05 },
   { 's', 't', 0xfb06 },
 
+  // extra alternatives, easier to remember
+  {'W', '`', 0x1e80},
+  {'w', '`', 0x1e81},
+  {'Y', '`', 0x1ef2},
+  {'y', '`', 0x1ef3},
+
   // Vim 5.x compatible digraphs that don't conflict with the above
   { '~', '!', 161 },  // ¡
   { 'c', '|', 162 },  // ¢


### PR DESCRIPTION
    Problem:    Some unicode digraphs are hard to remember.
    Solution:   Add alternatives with a backtick. (Chris Harding, closes #1861)
    https://github.com/vim/vim/commit/816e7660e1efb918ad85b5c78d21b957d1bcad17